### PR TITLE
feat(nginx): 添加nginx反向代理配置及docker-compose支持

### DIFF
--- a/mcps/docker-compose.yml
+++ b/mcps/docker-compose.yml
@@ -8,11 +8,10 @@ services:
       - SSE_LOCAL=${FIRECRAWL_SSE_LOCAL}
     restart: always
 
-  # proxy:
-  #   build: ./reverse-proxy
-  #   depends_on:
-  #     - mcp-fs
-  #     - mcp-git
-  #   ports:
-  #     - "8080:8080"       # 映射到 dind 容器的 8080（外层再映射到宿主机）
-  #   restart: unless-stopped
+  proxy:
+    build: ./nginx
+    depends_on:
+      - firecrawl-mcp
+    ports:
+      - "8080:8080"       # 映射到 dind 容器的 8080（外层再映射到宿主机）
+    restart: unless-stopped

--- a/mcps/nginx/Dockerfile
+++ b/mcps/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.25-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8080

--- a/mcps/nginx/nginx.conf
+++ b/mcps/nginx/nginx.conf
@@ -1,0 +1,35 @@
+worker_processes auto;
+events { worker_connections 1024; }
+
+http {
+  access_log /dev/stdout;
+  error_log  /dev/stderr info;
+
+  proxy_http_version 1.1;
+  proxy_buffering off;
+  proxy_read_timeout 1h;
+  proxy_send_timeout 1h;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+  server {
+    listen 8080;
+
+    location = /_ok {
+      return 200 'ok';
+      add_header Content-Type text/plain;
+    }
+
+    location /firecrawl/ {
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_pass http://firecrawl-mcp:3000/;
+    }
+  }
+}


### PR DESCRIPTION
添加nginx Dockerfile和配置文件，用于反向代理firecrawl-mcp服务
在docker-compose中启用proxy服务，映射8080端口